### PR TITLE
Throw an exception if GetAccessTokenAsync returns an error

### DIFF
--- a/src/Authorization/OneDriveOAuthLogic.cs
+++ b/src/Authorization/OneDriveOAuthLogic.cs
@@ -69,7 +69,9 @@ namespace DG.OneDrive.Authorization
                 );
 
             var client = HttpClientProvider.ClientForSettings(_httpClientSettings);
-            var token = await client.SendAndDeserializeAsync<AccessToken>(tokenRequest).ConfigureAwait(false);
+            var result = await client.SendAsync(tokenRequest).ConfigureAwait(false);
+            result.EnsureSuccessStatusCode();
+            var token = await result.DeserializeResponseAsync<AccessToken>().ConfigureAwait(false);
 
             return new OAuthToken(token.access_token, token.ExpirationDate, token.refresh_token);
         }

--- a/src/DG.OneDrive.csproj
+++ b/src/DG.OneDrive.csproj
@@ -3,7 +3,7 @@
     <ProjectGuid>{9F5EEB80-2CAC-4AD6-985A-603A3F21E743}</ProjectGuid>
     <TargetFramework>net452</TargetFramework>
     <AssemblyTitle>DG.OneDrive</AssemblyTitle>
-    <AssemblyVersion>0.3.9</AssemblyVersion>
+    <AssemblyVersion>0.3.10</AssemblyVersion>
     <Product>DG.OneDrive</Product>
     <Copyright>Copyright ©  2023</Copyright>
     <OutputPath>bin\$(Configuration)\</OutputPath>


### PR DESCRIPTION
This happens in case of expired client secret